### PR TITLE
Error handling sites

### DIFF
--- a/Controllers/siteController.js
+++ b/Controllers/siteController.js
@@ -1,13 +1,13 @@
 const { retrieveSites, addAnotherSite } = require("../Models/siteModel");
 
-exports.getSites = async (req, res) => {
+exports.getSites = async (req, res, next) => {
   const { author_id } = req.query;
-  const sites = await retrieveSites(author_id);
+  const sites = await retrieveSites(author_id).catch((err) => next(err));
   res.status(200).send(sites);
 };
 
-exports.postSite = async (req, res) => {
+exports.postSite = async (req, res, next) => {
   const newSite = req.body;
-  const addedSite = await addAnotherSite(newSite);
+  const addedSite = await addAnotherSite(newSite).catch((err) => next(err));
   res.status(201).send(addedSite);
 };

--- a/Models/siteModel.js
+++ b/Models/siteModel.js
@@ -16,6 +16,31 @@ exports.retrieveSites = async (author_id) => {
 };
 
 exports.addAnotherSite = async (newSite) => {
+  if (
+    newSite.authorID === undefined ||
+    newSite.siteName === undefined ||
+    newSite.siteDescription === undefined ||
+    newSite.siteImage === undefined ||
+    newSite.siteAddress === undefined ||
+    newSite.latitude === undefined ||
+    newSite.longitude === undefined ||
+    newSite.contactInfo === undefined ||
+    newSite.websiteLink === undefined
+  ) {
+    return Promise.reject({ status: 400, msg: "Missing Input Information!" });
+  } else if (
+    typeof newSite.authorID !== "number" ||
+    typeof newSite.siteName !== "string" ||
+    typeof newSite.siteDescription !== "string" ||
+    typeof newSite.siteImage !== "string" ||
+    typeof newSite.siteAddress !== "string" ||
+    typeof newSite.latitude !== "number" ||
+    typeof newSite.longitude !== "number" ||
+    typeof newSite.contactInfo !== "string" ||
+    typeof newSite.websiteLink !== "string"
+  ) {
+    return Promise.reject({ status: 400, msg: "Invalid Input" });
+  }
   return Site.create(newSite).then((createdSite) => {
     return createdSite;
   });

--- a/Models/siteModel.js
+++ b/Models/siteModel.js
@@ -3,6 +3,9 @@ const Site = require("../siteQuery");
 exports.retrieveSites = async (author_id) => {
   if (author_id) {
     return Site.find({ authorID: author_id }).then((sites) => {
+      if (!sites.length) {
+        return Promise.reject({ status: 404, msg: "Author ID does not exist" });
+      }
       return sites;
     });
   } else {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -59,17 +59,6 @@ describe("Testing the sites endpoint", () => {
       });
   });
 
-  test("should return an empty when passed an ID with no associated sites", () => {
-    return request(app)
-      .get("/sites?author_id=0")
-      .expect(200)
-      .then(({ body }) => {
-        const sites = body;
-        expect(sites).toBeInstanceOf(Array);
-        expect(sites).toHaveLength(0);
-      });
-  });
-
   test("should post a new site into site db, status 201", () => {
     return request(app)
       .post("/sites")
@@ -101,6 +90,24 @@ describe("Testing the sites endpoint", () => {
             websiteLink: "String",
           })
         );
+      });
+  });
+
+  test.only("should return a status 404 when passed an Author ID with no associated sites", () => {
+    return request(app)
+      .get("/sites?author_id=23")
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe("Author ID does not exist");
+      });
+  });
+
+  test("should return a status 400 when passed an invalid input", () => {
+    return request(app)
+      .get("/sites?author_id=dsahk")
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe("Invalid ID input");
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -93,7 +93,7 @@ describe("Testing the sites endpoint", () => {
       });
   });
 
-  test.only("should return a status 404 when passed an Author ID with no associated sites", () => {
+  test("should return a status 404 when passed an Author ID with no associated sites", () => {
     return request(app)
       .get("/sites?author_id=23")
       .expect(404)
@@ -107,7 +107,46 @@ describe("Testing the sites endpoint", () => {
       .get("/sites?author_id=dsahk")
       .expect(400)
       .then((res) => {
-        expect(res.body.msg).toBe("Invalid ID input");
+        expect(res.body.msg).toBe("Invalid Input");
+      });
+  });
+
+  test("should return status 400 when missing info on posted site", () => {
+    return request(app)
+      .post("/sites")
+      .send({
+        authorID: 12,
+        siteName: "String",
+        siteDescription: "String",
+        siteImage: "String",
+        latitude: 1232,
+        longitude: 1232,
+        contactInfo: "String",
+        websiteLink: "String",
+      })
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe("Missing Input Information!");
+      });
+  });
+
+  test("should return status 400 when given incorrect data on site posting", () => {
+    return request(app)
+      .post("/sites")
+      .send({
+        authorID: 12,
+        siteName: "String",
+        siteDescription: "String",
+        siteImage: "String",
+        siteAddress: "String",
+        latitude: "1232",
+        longitude: 1232,
+        contactInfo: "String",
+        websiteLink: "String",
+      })
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe("Invalid Input");
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -22,15 +22,8 @@ app.get("/sites", getSites);
 app.post("/sites", postSite);
 
 app.use((err, req, res, next) => {
-  console.log(err);
-  if (err.reason.code === "ERR_ASSERTION") {
-    console.log("heeelloooooooo if statement");
-    res.status(400).send({ msg: "Invalid ID input" });
-  } else {
-    console.log("heellloo else statement");
-    res.status(err.status).send({ msg: err.msg });
-  }
-  console.log("heellllo end of code");
+  if (err.msg) res.status(err.status).send({ msg: err.msg });
+  res.status(400).send({ msg: "Invalid ID input" });
 });
 
 app.listen(port, () => console.log(`Listening on port ${port}`));

--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ app.post("/sites", postSite);
 
 app.use((err, req, res, next) => {
   if (err.msg) res.status(err.status).send({ msg: err.msg });
-  res.status(400).send({ msg: "Invalid ID input" });
+  res.status(400).send({ msg: "Invalid Input" });
 });
 
 app.listen(port, () => console.log(`Listening on port ${port}`));

--- a/app.js
+++ b/app.js
@@ -21,6 +21,18 @@ app.use(express.json());
 app.get("/sites", getSites);
 app.post("/sites", postSite);
 
+app.use((err, req, res, next) => {
+  console.log(err);
+  if (err.reason.code === "ERR_ASSERTION") {
+    console.log("heeelloooooooo if statement");
+    res.status(400).send({ msg: "Invalid ID input" });
+  } else {
+    console.log("heellloo else statement");
+    res.status(err.status).send({ msg: err.msg });
+  }
+  console.log("heellllo end of code");
+});
+
 app.listen(port, () => console.log(`Listening on port ${port}`));
 
 module.exports = app;

--- a/siteQuery.js
+++ b/siteQuery.js
@@ -1,17 +1,20 @@
 const mongoose = require("mongoose");
 const AutoIncrement = require("mongoose-sequence")(mongoose);
 
-const SiteSchema = mongoose.Schema({
-  authorID: Number,
-  siteName: String,
-  siteDescription: String,
-  siteImage: String,
-  siteAddress: String,
-  latitude: Number,
-  longitude: Number,
-  contactInfo: String,
-  websiteLink: String,
-});
+const SiteSchema = mongoose.Schema(
+  {
+    authorID: Number,
+    siteName: String,
+    siteDescription: String,
+    siteImage: String,
+    siteAddress: String,
+    latitude: Number,
+    longitude: Number,
+    contactInfo: String,
+    websiteLink: String,
+  },
+  { timestamps: true }
+);
 
 SiteSchema.plugin(AutoIncrement, { inc_field: "siteId" });
 module.exports = mongoose.model("site", SiteSchema);


### PR DESCRIPTION
Handles the following errors for the /sites endpoint:
-Return status 404 for if author_id query doesn't match existing author id.
-Returns status  400 if author_id query is not a number.
-Return status 400 if missing info in the body of post request.

It also:
-Implemented lastUpdated and createdAt in site Schema.
 
