### PR TITLE
Add query for site IDs and error handling

### DIFF
--- a/Controllers/siteController.js
+++ b/Controllers/siteController.js
@@ -1,8 +1,10 @@
 const { retrieveSites, addAnotherSite } = require("../Models/siteModel");
 
 exports.getSites = async (req, res, next) => {
-  const { author_id } = req.query;
-  const sites = await retrieveSites(author_id).catch((err) => next(err));
+  const { author_id, site_ids } = req.query;
+  const sites = await retrieveSites(author_id, site_ids).catch((err) =>
+    next(err)
+  );
   res.status(200).send(sites);
 };
 

--- a/Models/siteModel.js
+++ b/Models/siteModel.js
@@ -1,10 +1,23 @@
 const Site = require("../siteQuery");
 
-exports.retrieveSites = async (author_id) => {
+exports.retrieveSites = async (author_id, site_ids) => {
   if (author_id) {
     return Site.find({ authorID: author_id }).then((sites) => {
       if (!sites.length) {
         return Promise.reject({ status: 404, msg: "Author ID does not exist" });
+      }
+      return sites;
+    });
+  } else if (site_ids) {
+    const ids = JSON.parse(site_ids);
+    if (!Array.isArray(ids))
+      return Promise.reject({
+        status: 400,
+        msg: "Site IDs should be an array",
+      });
+    return Site.find({ siteId: { $in: ids } }).then((sites) => {
+      if (!sites.length) {
+        return Promise.reject({ status: 404, msg: "No sites found" });
       }
       return sites;
     });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -59,6 +59,32 @@ describe("Testing the sites endpoint", () => {
       });
   });
 
+  test("should return all associated sites from an array of siteIDs", () => {
+    return request(app)
+      .get("/sites?site_ids=[1, 2]")
+      .expect(200)
+      .then(({ body }) => {
+        const sites = body;
+        expect(sites).toBeInstanceOf(Array);
+        expect(sites).toHaveLength(2);
+        sites.forEach((site) => {
+          expect(site).toEqual(
+            expect.objectContaining({
+              authorID: expect.any(Number),
+              siteName: expect.any(String),
+              siteDescription: expect.any(String),
+              siteImage: expect.any(String),
+              siteAddress: expect.any(String),
+              latitude: expect.any(Number),
+              longitude: expect.any(Number),
+              contactInfo: expect.any(String),
+              websiteLink: expect.any(String),
+            })
+          );
+        });
+      });
+  });
+
   test("should post a new site into site db, status 201", () => {
     return request(app)
       .post("/sites")
@@ -108,6 +134,33 @@ describe("Testing the sites endpoint", () => {
       .expect(400)
       .then((res) => {
         expect(res.body.msg).toBe("Invalid Input");
+      });
+  });
+
+  test("should return a status 404 when passed an empty array as the sites_id query", () => {
+    return request(app)
+      .get("/sites?site_ids=[]")
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe("No sites found");
+      });
+  });
+
+  test("should return a status 404 when passed an array with site ids not matching any site", () => {
+    return request(app)
+      .get("/sites?site_ids=[200, 201]")
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe("No sites found");
+      });
+  });
+
+  test("should return a status 400 when passed a site_ids query not matching an array", () => {
+    return request(app)
+      .get("/sites?site_ids=211")
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe("Site IDs should be an array");
       });
   });
 


### PR DESCRIPTION
1. Can make a GET request to /sites with an array of site_ids to retrieve all matching sites
2. Added 404 error for site_ids not matching any sites in the database
3. Added 400 error for passing an invalid query parameter (i.e. not an array)
4. Added appropriate tests