### PR TITLE
Add query for tour code and removed console.logs

### DIFF
--- a/Controllers/tourController.js
+++ b/Controllers/tourController.js
@@ -8,8 +8,10 @@ const {
 const generateUniqueId = require("generate-unique-id");
 
 exports.getTours = async (req, res, next) => {
-  const { author_id } = req.query;
-  const tours = await fetchTours(author_id).catch((err) => next(err));
+  const { author_id, tour_code } = req.query;
+  const tours = await fetchTours(author_id, tour_code).catch((err) =>
+    next(err)
+  );
   res.status(200).send(tours);
 };
 
@@ -19,7 +21,7 @@ exports.getTourById = async (req, res) => {
   res.status(200).send(tour);
 };
 
-exports.postTour = async (req, res) => {
+exports.postTour = async (req, res, next) => {
   const newTour = req.body;
   const id = generateUniqueId({
     length: 6,

--- a/Models/siteModel.js
+++ b/Models/siteModel.js
@@ -60,7 +60,6 @@ exports.addAnotherSite = async (newSite) => {
 };
 
 exports.fetchedSiteById = async (site_id) => {
-  console.log(site_id);
   return Site.find({ siteId: site_id }).then((siteById) => {
     return siteById;
   });

--- a/Models/tourModel.js
+++ b/Models/tourModel.js
@@ -1,12 +1,19 @@
 const Tour = require("../tourQuery");
 
-exports.fetchTours = async (author_id) => {
+exports.fetchTours = async (author_id, tour_code) => {
   if (author_id) {
     return Tour.find({ authorId: author_id }).then((tours) => {
       if (!tours.length) {
         return Promise.reject({ status: 404, msg: "Author ID does not exist" });
       }
       return tours;
+    });
+  } else if (tour_code) {
+    return Tour.find({ tourCode: tour_code }).then((tour) => {
+      if (!tour.length) {
+        return Promise.reject({ status: 404, msg: "Tour code does not exist" });
+      }
+      return tour;
     });
   } else {
     return Tour.find().then((tours) => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -225,6 +225,29 @@ describe("Testing the tours endpoint", () => {
       });
   });
 
+  test("should return corresponding associated tours by stated tour code", () => {
+    return request(app)
+      .get("/tours?tour_code=123456")
+      .expect(200)
+      .then(({ body }) => {
+        const tours = body;
+        expect(tours).toBeInstanceOf(Array);
+        expect(tours).toHaveLength(1);
+        tours.forEach((tour) => {
+          expect(tour).toEqual(
+            expect.objectContaining({
+              tourId: expect.any(Number),
+              tourCode: 123456,
+              tourName: expect.any(String),
+              tourDescription: expect.any(String),
+              tourImage: expect.any(String),
+              tourSites: expect.any(Array),
+            })
+          );
+        });
+      });
+  });
+
   test("should post a new tour into site db, status 201", () => {
     return request(app)
       .post("/tours")
@@ -267,6 +290,24 @@ describe("Testing the tours endpoint", () => {
   test("should return a status 400 when passed an invalid input", () => {
     return request(app)
       .get("/tours?author_id=dsahk")
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe("Invalid Input");
+      });
+  });
+
+  test("should return status 404 when passed a tour code with no associated tours", () => {
+    return request(app)
+      .get("/tours?tour_code=123452")
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe("Tour code does not exist");
+      });
+  });
+
+  test("should return status 400 when passed an invalid tour code", () => {
+    return request(app)
+      .get("/tours?tour_code=banana")
       .expect(400)
       .then((res) => {
         expect(res.body.msg).toBe("Invalid Input");


### PR DESCRIPTION
1. Can query /tours with a tour code, returning a 200 and the corresponding tour object
2. Returns a 404 if no tour code is found
3. Returns a 400 if tour code is not a number
4. Removed console.logs from tests