### PR TITLE
error handling for 'tours/:tour_id'

### DIFF
--- a/Controllers/tourController.js
+++ b/Controllers/tourController.js
@@ -13,13 +13,13 @@ exports.getTours = async (req, res, next) => {
   res.status(200).send(tours);
 };
 
-exports.getTourById = async (req, res) => {
+exports.getTourById = async (req, res, next) => {
   const { tour_id } = req.params;
-  const tour = await fetchTourById(tour_id);
+  const tour = await fetchTourById(tour_id).catch((err) => next(err));
   res.status(200).send(tour);
 };
 
-exports.postTour = async (req, res) => {
+exports.postTour = async (req, res, next) => {
   const newTour = req.body;
   const id = generateUniqueId({
     length: 6,
@@ -30,16 +30,24 @@ exports.postTour = async (req, res) => {
   res.status(201).send(addedTour);
 };
 
-exports.updateTour = async (req, res) => {
+exports.updateTour = async (req, res, next) => {
   const { tour_id } = req.params;
-  const updates = req.body;
-  await changeTour(tour_id, updates);
-  const tour = await fetchTourById(tour_id);
-  res.status(200).send(tour);
+  try {
+    const updates = req.body;
+    await changeTour(tour_id, updates);
+    const tour = await fetchTourById(tour_id);
+    res.status(200).send(tour);
+  } catch (err) {
+    next(err);
+  }
 };
 
-exports.deleteTour = async (req, res) => {
+exports.deleteTour = async (req, res, next) => {
   const { tour_id } = req.params;
-  await removeTour(tour_id);
-  res.sendStatus(204);
+  try {
+    await removeTour(tour_id);
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
 };

--- a/Models/tourModel.js
+++ b/Models/tourModel.js
@@ -17,6 +17,9 @@ exports.fetchTours = async (author_id) => {
 
 exports.fetchTourById = async (tour_id) => {
   return Tour.find({ tourId: tour_id }).then((tour) => {
+    if (!tour.length) {
+      return Promise.reject({ status: 404, msg: "Tour does not exist" });
+    }
     return tour;
   });
 };
@@ -51,5 +54,9 @@ exports.changeTour = async (tour_id, updates) => {
 };
 
 exports.removeTour = async (tour_id) => {
-  return Tour.deleteOne({ tourId: tour_id });
+  return Tour.deleteOne({ tourId: tour_id }).then((res) => {
+    if (res.deletedCount === 0) {
+      return Promise.reject({ status: 404, msg: "Tour does not exist" });
+    }
+  });
 };

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -370,4 +370,71 @@ describe("Testing tours endpoint with specified tour_ids", () => {
         );
       });
   });
+
+  test("should return a status 404 for GET when passed an tour ID with no associated tours", () => {
+    return request(app)
+      .get("/tours/999")
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe("Tour does not exist");
+      });
+  });
+
+  test("should return a status 400 for GET when passed an invalid input", () => {
+    return request(app)
+      .get("/tours/one")
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe("Invalid Input");
+      });
+  });
+
+  test("should return a status 404 for DELETE when passed a non existant tour ID", () => {
+    return request(app)
+      .delete("/tours/999")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Tour does not exist");
+      });
+  });
+
+  test("should return a status 400 for delete when passed a invalid body", () => {
+    return request(app)
+      .patch("/tours/1")
+      .send({ tourCode: "onetwothree" })
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid Input");
+      });
+  });
+
+  test("should return status 400 when passed a body with both valid and invalid values AND the tour should remain unchaed", () => {
+    return request(app)
+      .patch("/tours/1")
+      .send({ tourName: "New Tour", tourCode: "onetwothree" })
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid Input");
+      })
+      .then(() => {
+        return request(app)
+          .get("/tours/1")
+          .expect(200)
+          .then(({ body }) => {
+            const tour = body[0];
+            expect(tour).toEqual(
+              expect.objectContaining({
+                tourId: 1,
+                authorId: 1,
+                tourCode: 123456,
+                tourName: "Tour of Durham",
+                tourDescription: "A tour of historic Durham",
+                tourImage:
+                  "https://myguideimages.s3.eu-west-2.amazonaws.com/durham_cathedral.jpg",
+                tourSites: [1, 2, 3, 4],
+              })
+            );
+          });
+      });
+  });
 });


### PR DESCRIPTION
This branch handles errors for the "tours/tour_id" endpoint:

- GET request return 404 if the tour_id does not exist in database
- GET request returns 400 if tour_id is not a number 
- PATCH request return 404 if tour_id does not exist in database
- PATCH request returns 400 if any invalid information on request body
- DELETE request returns 404 if tour_id does not exist in database
