### PR TITLE
fixed post site bug when there is an invalid input

### DIFF
--- a/error/index.js
+++ b/error/index.js
@@ -1,4 +1,7 @@
 exports.handleError = (err, req, res, next) => {
-  if (err.msg) res.status(err.status).send({ msg: err.msg });
-  res.status(400).send({ msg: "Invalid Input" });
+  if (err.msg) {
+    res.status(err.status).send({ msg: err.msg });
+  } else {
+    res.status(400).send({ msg: "Invalid Input" });
+  }
 };


### PR DESCRIPTION
- handleError was sending back both res.send statements. Changing it to an if else statement fixed it. All tests are passing and no ERR_HTTP_HEADERS_SENT when posting a site with an invalid input. 